### PR TITLE
SwiftSyntaxとSwiftFormatを600にアップグレードする

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "46989693916f56d1186bd59ac15124caef896560",
-        "version" : "1.3.1"
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
       }
     },
     {
@@ -14,17 +14,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-cmark.git",
       "state" : {
-        "revision" : "f218e5d7691f78b55bfa39b367763f4612486c35",
-        "version" : "0.3.0"
+        "revision" : "3bc2f3e25df0cecc5dc269f7ccae65d0f386f06a",
+        "version" : "0.4.0"
       }
     },
     {
       "identity" : "swift-format",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-format",
+      "location" : "https://github.com/swiftlang/swift-format",
       "state" : {
-        "revision" : "7996ac678197d293f6c088a1e74bb778b4e10139",
-        "version" : "510.1.0"
+        "revision" : "65f9da9aad84adb7e2028eb32ca95164aa590e3b",
+        "version" : "600.0.0"
       }
     },
     {
@@ -32,17 +32,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-markdown.git",
       "state" : {
-        "revision" : "e4f95e2dc23097a1a9a1dfdfe3fe3ee44de77378",
-        "version" : "0.3.0"
+        "revision" : "4aae40bf6fff5286e0e1672329d17824ce16e081",
+        "version" : "0.4.0"
       }
     },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
-        "version" : "510.0.1"
+        "revision" : "cb53fa1bd3219b0b23ded7dfdd3b2baff266fd25",
+        "version" : "600.0.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -4,16 +4,16 @@ import PackageDescription
 
 let package = Package(
     name: "CodegenKit",
-    platforms: [.macOS(.v10_15)],
+    platforms: [.macOS(.v12)],
     products: [
         .library(name: "CodegenKit", targets: ["CodegenKit"]),
         .library(name: "CodeTemplateModule", targets: ["CodeTemplateModule"]),
         .plugin(name: "CodegenKitPlugin", targets: ["CodegenKitPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-format", "509.0.0"..<"999.0.0"),
-        .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"999.0.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.4")
+        .package(url: "https://github.com/swiftlang/swift-format", "600.0.0"..<"999.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"999.0.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -11,9 +11,9 @@ let package = Package(
         .plugin(name: "CodegenKitPlugin", targets: ["CodegenKitPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-format", "600.0.0"..<"999.0.0"),
-        .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"999.0.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0")
+        .package(url: "https://github.com/swiftlang/swift-format.git", "600.0.0"..<"999.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0"..<"999.0.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0")
     ],
     targets: [
         .target(

--- a/Sources/CodegenKit/CodegenRunner.swift
+++ b/Sources/CodegenKit/CodegenRunner.swift
@@ -1,11 +1,10 @@
 import Foundation
 import SwiftFormat
-import SwiftFormatConfiguration
 
 public final class CodegenRunner {
     public init(
         renderers: [any Renderer],
-        formatConfiguration: SwiftFormatConfiguration.Configuration? = nil
+        formatConfiguration: SwiftFormat.Configuration? = nil
     ) {
         self.renderers = renderers
         self.formatConfiguration = formatConfiguration ?? Self.defaultFormatCondiguration()
@@ -13,11 +12,11 @@ public final class CodegenRunner {
     }
 
     public var renderers: [any Renderer]
-    public var formatConfiguration: SwiftFormatConfiguration.Configuration
+    public var formatConfiguration: SwiftFormat.Configuration
     private let fileManager: FileManager
 
-    public static func defaultFormatCondiguration() -> SwiftFormatConfiguration.Configuration {
-        var c = SwiftFormatConfiguration.Configuration()
+    public static func defaultFormatCondiguration() -> SwiftFormat.Configuration {
+        var c = SwiftFormat.Configuration()
         c.lineLength = 10000
         c.indentation = .spaces(4)
         return c
@@ -54,7 +53,7 @@ public final class CodegenRunner {
     public func format(source: String, file: URL) throws -> String {
         let formatter = SwiftFormatter(configuration: formatConfiguration)
         var result = ""
-        try formatter.format(source: source, assumingFileURL: file, to: &result)
+        try formatter.format(source: source, assumingFileURL: file, selection: .infinite, to: &result)
         return result
     }
 

--- a/Sources/CodegenKitCLI/ManifestoCode.swift
+++ b/Sources/CodegenKitCLI/ManifestoCode.swift
@@ -3,13 +3,12 @@ import SwiftOperators
 import SwiftSyntax
 import SwiftParser
 import SwiftFormat
-import SwiftFormatConfiguration
 import CodegenKit
 
 struct ManifestoCode {
     init(
         fileManager: FileManager,
-        formatConfiguration: SwiftFormatConfiguration.Configuration,
+        formatConfiguration: SwiftFormat.Configuration,
         file: URL
     ) throws {
         guard fileManager.fileExists(atPath: file.path) else {
@@ -22,7 +21,7 @@ struct ManifestoCode {
     }
 
     var fileManager: FileManager
-    var formatConfiguration: SwiftFormatConfiguration.Configuration
+    var formatConfiguration: SwiftFormat.Configuration
     var file: URL
     var source: String
 
@@ -30,7 +29,10 @@ struct ManifestoCode {
         let syntax = parse()
         let formatter = SwiftFormatter(configuration: formatConfiguration)
         var out = ""
-        try formatter.format(syntax: syntax, operatorTable: OperatorTable(), assumingFileURL: file, to: &out)
+        try formatter.format(
+            syntax: syntax, source: source, operatorTable: OperatorTable(),
+            assumingFileURL: file, selection: .infinite, to: &out
+        )
         self.source = out
     }
 

--- a/Sources/CodegenKitCLI/RepositoryInitializer.swift
+++ b/Sources/CodegenKitCLI/RepositoryInitializer.swift
@@ -3,13 +3,12 @@ import SwiftSyntax
 import SwiftParser
 import SwiftSyntaxBuilder
 import SwiftFormat
-import SwiftFormatConfiguration
 import CodegenKit
 
 public struct RepositoryInitializer {
     public init(
         directory: URL,
-        formatConfiguration: SwiftFormatConfiguration.Configuration = Self.defaultFormatConfiguration
+        formatConfiguration: SwiftFormat.Configuration = Self.defaultFormatConfiguration
     ) {
         self.directory = directory
         self.formatConfiguration = formatConfiguration
@@ -17,9 +16,9 @@ public struct RepositoryInitializer {
     }
 
     public var directory: URL
-    public var formatConfiguration: SwiftFormatConfiguration.Configuration
+    public var formatConfiguration: SwiftFormat.Configuration
 
-    public static var defaultFormatConfiguration: SwiftFormatConfiguration.Configuration {
+    public static var defaultFormatConfiguration: SwiftFormat.Configuration {
         var c = Configuration()
         c.lineLength = 10000
         c.indentation = .spaces(4)

--- a/Tests/CodegenKitCLITests/ExampleManifesto.swift
+++ b/Tests/CodegenKitCLITests/ExampleManifesto.swift
@@ -3,11 +3,10 @@ import SwiftOperators
 import SwiftSyntax
 import SwiftParser
 import SwiftFormat
-import SwiftFormatConfiguration
 import CodegenKitCLI
 
 struct ExampleManifesto {
-    var formatConfiguration: SwiftFormatConfiguration.Configuration = RepositoryInitializer.defaultFormatConfiguration
+    var formatConfiguration: SwiftFormat.Configuration = RepositoryInitializer.defaultFormatConfiguration
 
     var hasDefaultLocalization: Bool = false
     var hasPlatforms: Bool = false
@@ -135,7 +134,10 @@ let package = Package(
         let syntax = Parser.parse(source: source)
         let formatter = SwiftFormatter(configuration: formatConfiguration)
         var out = ""
-        try formatter.format(syntax: syntax, operatorTable: OperatorTable(), assumingFileURL: file, to: &out)
+        try formatter.format(
+            syntax: syntax, source: source, operatorTable: OperatorTable(),
+            assumingFileURL: file, selection: .infinite, to: &out
+        )
         return out
     }
 }


### PR DESCRIPTION
出たので追従する

特に swift-format から swift-syntax への参照が `apple/` から `swiftlang/` に修正されているのが重要
codegenkit→swift-format→swift-syntaxで `apple/` が混じり込むことで警告が表示されてしまうため

なお600になるとswift-syntaxが一部互換性を失っていたため、
codegenkitもメジャーバージョンを更新する必要がある