### PR TITLE
swift-format を外す

### DIFF
--- a/Docs/CodeTemplateModule.md
+++ b/Docs/CodeTemplateModule.md
@@ -1,11 +1,11 @@
 # CodeTemplate
 
-Small library for support **in place** code generation.
-You can use this module independently from CodegenKit. 
+`CodeTemplateModule` is a small library for in-place code generation. It can be
+used independently from CodegenKit.
 
 ## Usage
 
-Write code as template with markers.
+Mark generated regions directly in a source file:
 
 ```swift
 // Visitor.swift
@@ -18,7 +18,7 @@ class Visitor {
 }
 ```
 
-Load code as template, edit, save.
+Load the file as a template, replace a placeholder, and write the file back:
 
 ```swift
 let file = URL(fileURLWithPath: "Visitor.swift")
@@ -27,7 +27,13 @@ template["visitImpl"] = generateVisitImpl()
 try template.description.write(to: file, atomically: true, encoding: .utf8)
 ```
 
-## Detail
+## Details
 
-CodeTemplate just split source file by lines.
-It doesn't see any syntax like comments, so it's target language agnostic.
+`CodeTemplate` splits the source file by lines and looks for `@codegen` and
+`@end` markers. It does not parse the surrounding language, comments, or syntax,
+so the module is language-agnostic.
+
+When a placeholder is parsed, `CodeTemplate` records the indentation of the
+`@codegen` marker line. Placeholder contents are exposed without that base
+indentation. When the template is rendered back to text, the marker indentation
+is added to each non-empty generated line.

--- a/Docs/init.md
+++ b/Docs/init.md
@@ -1,8 +1,8 @@
-# Setup instructions
+# Setup Instructions
 
-## Step 1. Install CodegenKit into your project
+## Step 1. Add CodegenKit To Your Package
 
-Add `CodegenKit` as dependency of your project.
+Add `CodegenKit` as a dependency of your project.
 
 ```swift
 let package = Package(
@@ -14,22 +14,20 @@ let package = Package(
 )
 ```
 
-## Step 2. Setup your project
+## Step 2. Initialize Your Project
 
-Perform command below.
+Run the initialization command:
 
+```sh
+swift package codegen-kit init
 ```
-$ swift package codegen-kit init
-```
 
-This is all that is needed to complete the required setup.
+This performs the required setup. If you prefer to configure the package
+manually, see [Setup Manually](#setup-manually).
 
-Instead of command, you can do it manually.
-In that case, see instructions described later in this document.
+## Step 3. Add Placeholders To Source Files
 
-## Step 3. Write placeholder into code
-
-Define placeholders with `@codegen` and `@end` as follows.
+Define placeholders with `// @codegen(...)` and `// @end` markers:
 
 ```swift
 // TSDecl.swift
@@ -41,14 +39,14 @@ extension TSDecl {
 }
 ```
 
-Attach name of placeholder at `@codegen`.
+The name inside `@codegen(...)` identifies the placeholder.
 
-## Step 4. Implement code renderer
+## Step 4. Implement A Renderer
 
-The init command created executable target named `codegen`.
-Add your renderer code into this.
+The init command creates an executable target named `codegen`. Add your renderer
+code to that target.
 
-Implement renderers to conform `CodegenKit.Renderer` as follows.
+Renderers conform to `CodegenKit.Renderer`:
 
 ```swift
 import Foundation
@@ -71,7 +69,7 @@ struct TSDeclRenderer: Renderer {
     }
 
     func asCasts() -> String {
-        let lines: [String] = nodes.map { (node) in
+        let lines: [String] = nodes.map { node in
             """
 public var as\(node.stem.pascal): \(node.typeName)? { self as? \(node.typeName) }
 """
@@ -81,21 +79,20 @@ public var as\(node.stem.pascal): \(node.typeName)? { self as? \(node.typeName) 
 }
 ```
 
-Specify target source code for this renderer with `isTarget` method.
+Use `isTarget(file:)` to choose which source files the renderer handles. Put the
+generation logic in `render(template:file:on:)`. The source file is provided as
+a `CodeTemplate`, and placeholders can be read or replaced through the template
+subscript.
 
-Write rendering logics into `render` method.
-Your source code are passwd as `CodeTemplate` object,
-you can edit content of placeholders via subscript.
+Render generated code from the left edge. CodegenKit reads the indentation of
+the `// @codegen(...)` marker and applies that base indentation when writing the
+generated code back to the file. Relative indentation inside the generated code
+is preserved.
 
-CodegenKit automatically format generated code by [swift-format](https://github.com/apple/swift-format).
-So you don't have to worry about precise textual control like indenting when write renderer.
+## Step 5. Register Renderers With The Runner
 
-## Step 5. Register your renderers to the runner.
-
-The init command created `main.swift` in `codegen` target.
-The codegen runner is defined in here.
-
-Edit this source to register your renderer to the runner.
+The init command creates a `main.swift` file in the `codegen` target. Register
+your renderers there:
 
 ```swift
 import CodegenKit
@@ -107,29 +104,29 @@ let dir = URL(fileURLWithPath: CommandLine.arguments[1])
 try runner.run(directories: [dir])
 ```
 
-## Step 6. Perform code generation
+## Step 6. Run Code Generation
 
-The init command created `codegen` command plugin.
-So you can perform code generation as below.
+The init command also creates a SwiftPM command plugin, so you can run:
 
+```sh
+swift package codegen
 ```
-$ swift package codegen
-```
 
-# More advanced code generation
+## More Advanced Code Generation
 
-CodegenKit initially creates `codegen` executable and plugin by the init command,
-but has no requirements for these specifications after that.
+The init command creates a `codegen` executable and command plugin as a starting
+point. After initialization, CodegenKit does not require that exact structure.
+You can change the executable, command-line interface, plugin, or renderer
+registration to fit more complex workflows.
 
-So, you can modify these targets source and build more complex code generations.
+# Setup Manually
 
-# Setup manually
+If you do not want to use the init command, configure the package with the
+following steps.
 
-To setup it manually without using the init command, do the following steps instead.
+## Step 1. Create A Codegen Executable
 
-## Step 1. Create codegen executable
-
-Create `codegen` executable target.
+Create an executable target that depends on CodegenKit.
 
 ```swift
 let package = Package(
@@ -145,9 +142,10 @@ let package = Package(
 )
 ```
 
-You can use any target name other than `codegen`.
+The target does not have to be named `codegen`; use any name that fits your
+project.
 
-Write main file that build `CodegenKit.CodegenRunner` and run it.
+Add a main file that builds and runs a `CodegenRunner`:
 
 ```swift
 import CodegenKit
@@ -159,24 +157,23 @@ let dir = URL(fileURLWithPath: CommandLine.arguments[1])
 try runner.run(directories: [dir])
 ```
 
-There are no specification about anything including command line arguments.
-Above example build as run on current working directory.
+CodegenKit does not impose any command-line argument format. The example above
+expects a directory path and runs generation in that directory.
 
-After that, you can generate code as below.
+You can then run code generation with:
 
-```
-$ swift run codegen .
-```
-
-## Step 2 (Optional). Create command plugin
-
-You can create [command plugin](https://github.com/apple/swift-evolution/blob/main/proposals/0332-swiftpm-command-plugins.md) 
-that perform previous `codegen` executable.
-
-After that, you can generate code as below.
-
-```
-$ swift package codegen
+```sh
+swift run codegen .
 ```
 
+## Step 2. Create A Command Plugin (Optional)
 
+You can also create a SwiftPM
+[command plugin](https://github.com/apple/swift-evolution/blob/main/proposals/0332-swiftpm-command-plugins.md)
+that invokes the codegen executable.
+
+With that plugin in place, you can run:
+
+```sh
+swift package codegen
+```

--- a/Package.resolved
+++ b/Package.resolved
@@ -10,33 +10,6 @@
       }
     },
     {
-      "identity" : "swift-cmark",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-cmark.git",
-      "state" : {
-        "revision" : "3bc2f3e25df0cecc5dc269f7ccae65d0f386f06a",
-        "version" : "0.4.0"
-      }
-    },
-    {
-      "identity" : "swift-format",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-format",
-      "state" : {
-        "revision" : "65f9da9aad84adb7e2028eb32ca95164aa590e3b",
-        "version" : "600.0.0"
-      }
-    },
-    {
-      "identity" : "swift-markdown",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-markdown.git",
-      "state" : {
-        "revision" : "4aae40bf6fff5286e0e1672329d17824ce16e081",
-        "version" : "0.4.0"
-      }
-    },
-    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,6 @@ let package = Package(
         .plugin(name: "CodegenKitPlugin", targets: ["CodegenKitPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-format.git", "600.0.0"..<"999.0.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0"..<"999.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0")
     ],
@@ -23,7 +22,8 @@ let package = Package(
         .target(
             name: "CodegenKit",
             dependencies: [
-                .product(name: "SwiftFormat", package: "swift-format"),
+                .product(name: "SwiftBasicFormat", package: "swift-syntax"),
+                .product(name: "SwiftParser", package: "swift-syntax"),
                 .target(name: "CodeTemplateModule")
             ]
         ),
@@ -36,7 +36,7 @@ let package = Package(
             dependencies: [
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
                 .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
-                .product(name: "SwiftFormat", package: "swift-format"),
+                .product(name: "SwiftBasicFormat", package: "swift-syntax"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .target(name: "CodegenKit")
             ]
@@ -64,6 +64,9 @@ let package = Package(
         .testTarget(
             name: "CodegenKitCLITests",
             dependencies: [
+                .product(name: "SwiftBasicFormat", package: "swift-syntax"),
+                .product(name: "SwiftParser", package: "swift-syntax"),
+                .target(name: "CodegenKit"),
                 .target(name: "CodegenKitCLI")
             ]
         )

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-# CodegenKit: Swift code generation framework
+# CodegenKit: a Swift code generation framework
 
-This is a framework for introducing code generation on your Swift project.
-You can do meta-programming like below.
+CodegenKit helps you add lightweight code generation to Swift projects. It lets
+you keep generated code directly in your Swift source files, while still making
+the generated regions easy to update.
 
-## Code becomes template as it is
+## Swift Code As The Template
 
-Placeholders are defined by markers in Swift code as follows.
+Placeholders are marked directly in Swift source code:
 
 ```swift
 protocol TSDecl {}
@@ -16,14 +17,14 @@ extension TSDecl {
 }
 ```
 
-Generated codes are inserted in area between markers.
+Generated code is written between the `// @codegen(...)` and `// @end` markers.
+CodegenKit does not require separate template files; your Swift source files are
+the templates.
 
-Thus, CodegenKit doesn't use any specific template files.
-Instead, Swift source codes are used as a template.
+## Write Renderers In Swift
 
-## Write code renderer in Swift
-
-Write code renderer as follows.
+A renderer decides which files it handles and writes generated code into named
+placeholders.
 
 ```swift
 import Foundation
@@ -46,7 +47,7 @@ struct TSDeclRenderer: Renderer {
     }
 
     func asCasts() -> String {
-        let lines: [String] = nodes.map { (node) in
+        let lines: [String] = nodes.map { node in
             """
 public var as\(node.stem.pascal): \(node.typeName)? { self as? \(node.typeName) }
 """
@@ -56,19 +57,49 @@ public var as\(node.stem.pascal): \(node.typeName)? { self as? \(node.typeName) 
 }
 ```
 
-Your source code are passed as `CodeTemplate` object.
-You can edit contents of placeholder via subscript.
+Source files are passed to renderers as `CodeTemplate` values. You can read and
+replace each placeholder through the template subscript.
 
-## Do code generation
+## Indentation
 
-After writing renderers, generate codes.
-Perform code generation with following command.
+CodegenKit uses the indentation of the `// @codegen(...)` marker as the base
+indentation for generated code.
 
+For example, this marker is indented by four spaces:
+
+```swift
+extension TSDecl {
+    // @codegen(as)
+    // @end
+}
 ```
-$ swift package codegen
+
+Every non-empty line assigned to `template["as"]` is written with those four
+spaces added.
+
+Renderers should generate code from the left edge, without the marker's base
+indentation:
+
+```swift
+template["as"] = """
+public var asClass: TSClassDecl? { self as? TSClassDecl }
+public var asField: TSFieldDecl? { self as? TSFieldDecl }
+"""
 ```
 
-Previous code will be edited as follows.
+Keep relative indentation inside generated code. CodegenKit adds the marker's
+base indentation to each non-empty line, but it does not infer or rewrite the
+internal indentation of the generated code.
+
+## Run Code Generation
+
+After writing renderers, run code generation with:
+
+```sh
+swift package codegen
+```
+
+The source file is updated in place:
 
 ```swift
 // TSDecl.swift
@@ -90,12 +121,9 @@ extension TSDecl {
 }
 ```
 
-Let's start and enjoy code generation!
-Please read [this document](Docs/init.md) for detailed setup instructions.
+For setup details, see [Setup instructions](Docs/init.md).
 
-# Documents
+## Documents
 
 - [Setup instructions](Docs/init.md)
 - [CodeTemplateModule sublibrary](Docs/CodeTemplateModule.md)
-
-

--- a/Sources/CodeTemplateModule/CodeTemplate.swift
+++ b/Sources/CodeTemplateModule/CodeTemplate.swift
@@ -3,7 +3,7 @@ import Foundation
 public struct CodeTemplate: CustomStringConvertible {
     enum Fragment: Hashable {
         case text(String)
-        case placeholder(name: String, content: String)
+        case placeholder(name: String, indentation: String, content: String)
 
         var text: String? {
             switch self {
@@ -14,9 +14,18 @@ public struct CodeTemplate: CustomStringConvertible {
 
         var placeholder: (name: String, content: String)? {
             switch self {
-            case .placeholder(name: let name, content: let content):
+            case .placeholder(name: let name, _, content: let content):
                 return (name: name, content: content)
             default: return nil
+            }
+        }
+
+        var placeholderIndentation: String? {
+            switch self {
+            case .placeholder(_, indentation: let indentation, _):
+                return indentation
+            default:
+                return nil
             }
         }
     }
@@ -45,7 +54,7 @@ public struct CodeTemplate: CustomStringConvertible {
         for (index, fragment) in fragments.enumerated() {
             switch fragment {
             case .text: break
-            case .placeholder(name: let name, _):
+            case .placeholder(name: let name, _, _):
                 indexMap[name] = index
             }
         }
@@ -63,7 +72,12 @@ public struct CodeTemplate: CustomStringConvertible {
         }
         set {
             guard let index = indexMap[name] else { return }
-            fragments[index] = .placeholder(name: name, content: newValue ?? "")
+            let indentation = fragments[index].placeholderIndentation ?? ""
+            fragments[index] = .placeholder(
+                name: name,
+                indentation: indentation,
+                content: newValue ?? ""
+            )
         }
     }
 
@@ -73,12 +87,36 @@ public struct CodeTemplate: CustomStringConvertible {
         for fragment in fragments {
             switch fragment {
             case .text(let text): result += text
-            case .placeholder(_, content: let text):
-                result += text.ensuringNewline()
+            case .placeholder(_, indentation: let indentation, content: let text):
+                result += text.ensuringNewline().indentingNonEmptyLines(with: indentation)
             }
         }
 
         return result
+    }
+}
+
+extension String {
+    func indentingNonEmptyLines(with indentation: String) -> String {
+        guard !indentation.isEmpty else { return self }
+        return splitLines().map { line in
+            line.contains { $0 != .lf && $0 != .cr && $0 != .crlf }
+                ? indentation + line
+                : line
+        }.joined()
+    }
+
+    func removingIndentationFromNonEmptyLines(_ indentation: String) -> String {
+        guard !indentation.isEmpty else { return self }
+        return splitLines().map { line in
+            guard line.contains(where: { $0 != .lf && $0 != .cr && $0 != .crlf }) else {
+                return line
+            }
+            guard line.hasPrefix(indentation) else {
+                return line
+            }
+            return String(line.dropFirst(indentation.count))
+        }.joined()
     }
 }
 

--- a/Sources/CodeTemplateModule/Parser.swift
+++ b/Sources/CodeTemplateModule/Parser.swift
@@ -15,7 +15,7 @@ final class Parser {
             }
             fragments.append(.text(text.text))
 
-            guard let placeholderName = text.nextPlaceholderName else {
+            guard let placeholder = text.nextPlaceholder else {
                 break
             }
             guard let placeholderContent = readPlaceholderFragment() else {
@@ -23,8 +23,11 @@ final class Parser {
             }
             fragments.append(
                 .placeholder(
-                    name: placeholderName,
-                    content: placeholderContent
+                    name: placeholder.name,
+                    indentation: placeholder.indentation,
+                    content: placeholderContent.removingIndentationFromNonEmptyLines(
+                        placeholder.indentation
+                    )
                 )
             )
         }
@@ -33,27 +36,30 @@ final class Parser {
 
     struct TextFragment {
         var text: String
-        var nextPlaceholderName: String?
+        var nextPlaceholder: (name: String, indentation: String)?
     }
 
     private func readTextFragment() -> TextFragment? {
         guard index < lines.count else { return nil }
 
         var text = ""
-        var placeholderName: String? = nil
+        var placeholder: (name: String, indentation: String)? = nil
         while index < lines.count {
             let line = lines[index]
             text += line
             index += 1
             if let mr = beginRegex.match(string: line) {
-                placeholderName = mr[1]
+                placeholder = (
+                    name: mr[1] ?? "",
+                    indentation: line.indentationBeforeMatch(mr)
+                )
                 break
             }
         }
 
         return TextFragment(
             text: text,
-            nextPlaceholderName: placeholderName
+            nextPlaceholder: placeholder
         )
     }
 
@@ -79,4 +85,14 @@ final class Parser {
     let endRegex = try! Regex(
         pattern: #"@end"#
     )
+}
+
+private extension String {
+    func indentationBeforeMatch(_ match: Regex.MatchResult) -> String {
+        guard let marker = match.entries.first?.range?.lowerBound else {
+            return ""
+        }
+
+        return String(self[..<marker].prefix { $0 == " " || $0 == "\t" })
+    }
 }

--- a/Sources/CodegenKit/CodegenFormatConfiguration.swift
+++ b/Sources/CodegenKit/CodegenFormatConfiguration.swift
@@ -1,0 +1,7 @@
+public struct CodegenFormatConfiguration: Sendable {
+    public init(indentationSpaces: Int = 4) {
+        self.indentationSpaces = indentationSpaces
+    }
+
+    public var indentationSpaces: Int
+}

--- a/Sources/CodegenKit/CodegenRunner.swift
+++ b/Sources/CodegenKit/CodegenRunner.swift
@@ -1,10 +1,11 @@
 import Foundation
-import SwiftFormat
+import SwiftBasicFormat
+import SwiftParser
 
 public final class CodegenRunner {
     public init(
         renderers: [any Renderer],
-        formatConfiguration: SwiftFormat.Configuration? = nil
+        formatConfiguration: CodegenFormatConfiguration? = nil
     ) {
         self.renderers = renderers
         self.formatConfiguration = formatConfiguration ?? Self.defaultFormatCondiguration()
@@ -12,14 +13,11 @@ public final class CodegenRunner {
     }
 
     public var renderers: [any Renderer]
-    public var formatConfiguration: SwiftFormat.Configuration
+    public var formatConfiguration: CodegenFormatConfiguration
     private let fileManager: FileManager
 
-    public static func defaultFormatCondiguration() -> SwiftFormat.Configuration {
-        var c = SwiftFormat.Configuration()
-        c.lineLength = 10000
-        c.indentation = .spaces(4)
-        return c
+    public static func defaultFormatCondiguration() -> CodegenFormatConfiguration {
+        CodegenFormatConfiguration()
     }
 
     public func run(directories: [URL]) throws {
@@ -51,10 +49,12 @@ public final class CodegenRunner {
     }
 
     public func format(source: String, file: URL) throws -> String {
-        let formatter = SwiftFormatter(configuration: formatConfiguration)
-        var result = ""
-        try formatter.format(source: source, assumingFileURL: file, selection: .infinite, to: &result)
-        return result
+        let syntax = Parser.parse(source: source)
+        let format = BasicFormat(
+            indentationWidth: .spaces(formatConfiguration.indentationSpaces),
+            viewMode: .fixedUp
+        )
+        return syntax.formatted(using: format).description
     }
 
     public func writeIfChanged(data: Data, file: URL) throws {

--- a/Sources/CodegenKitCLI/ManifestoCode.swift
+++ b/Sources/CodegenKitCLI/ManifestoCode.swift
@@ -1,14 +1,13 @@
 import Foundation
-import SwiftOperators
+import SwiftBasicFormat
 import SwiftSyntax
 import SwiftParser
-import SwiftFormat
 import CodegenKit
 
 struct ManifestoCode {
     init(
         fileManager: FileManager,
-        formatConfiguration: SwiftFormat.Configuration,
+        formatConfiguration: CodegenFormatConfiguration,
         file: URL
     ) throws {
         guard fileManager.fileExists(atPath: file.path) else {
@@ -21,19 +20,18 @@ struct ManifestoCode {
     }
 
     var fileManager: FileManager
-    var formatConfiguration: SwiftFormat.Configuration
+    var formatConfiguration: CodegenFormatConfiguration
     var file: URL
     var source: String
 
     mutating func format() throws {
-        let syntax = parse()
-        let formatter = SwiftFormatter(configuration: formatConfiguration)
-        var out = ""
-        try formatter.format(
-            syntax: syntax, source: source, operatorTable: OperatorTable(),
-            assumingFileURL: file, selection: .infinite, to: &out
+        let source = source.removingLeadingWhitespaceFromNonEmptyLines()
+        let syntax = Parser.parse(source: source)
+        let format = BasicFormat(
+            indentationWidth: .spaces(formatConfiguration.indentationSpaces),
+            viewMode: .fixedUp
         )
-        self.source = out
+        self.source = syntax.formatted(using: format).description
     }
 
     func write() throws {
@@ -198,7 +196,7 @@ struct ManifestoCode {
             if let last = dependencies.elements.last {
                 return try last.endPosition.samePosition(in: source)
             }
-            return try dependencies.rightSquare.positionAfterSkippingLeadingTrivia.samePosition(in: source)
+            return try dependencies.rightSquare.position.samePosition(in: source)
         }()
 
         var patch = """
@@ -225,6 +223,7 @@ struct ManifestoCode {
             ]
         ),
         """
+
         self.source.insert(contentsOf: "\n" + patch, at: position)
     }
 
@@ -269,4 +268,15 @@ struct ManifestoCode {
         self.source.insert(contentsOf: patch, at: position)
     }
 
+}
+
+private extension String {
+    func removingLeadingWhitespaceFromNonEmptyLines() -> String {
+        splitLines().map { line in
+            guard line.contains(where: { !$0.isNewline }) else {
+                return line
+            }
+            return String(line.drop(while: { $0 == " " || $0 == "\t" }))
+        }.joined()
+    }
 }

--- a/Sources/CodegenKitCLI/RepositoryInitializer.swift
+++ b/Sources/CodegenKitCLI/RepositoryInitializer.swift
@@ -2,13 +2,12 @@ import Foundation
 import SwiftSyntax
 import SwiftParser
 import SwiftSyntaxBuilder
-import SwiftFormat
 import CodegenKit
 
 public struct RepositoryInitializer {
     public init(
         directory: URL,
-        formatConfiguration: SwiftFormat.Configuration = Self.defaultFormatConfiguration
+        formatConfiguration: CodegenFormatConfiguration = Self.defaultFormatConfiguration
     ) {
         self.directory = directory
         self.formatConfiguration = formatConfiguration
@@ -16,13 +15,10 @@ public struct RepositoryInitializer {
     }
 
     public var directory: URL
-    public var formatConfiguration: SwiftFormat.Configuration
+    public var formatConfiguration: CodegenFormatConfiguration
 
-    public static var defaultFormatConfiguration: SwiftFormat.Configuration {
-        var c = Configuration()
-        c.lineLength = 10000
-        c.indentation = .spaces(4)
-        return c
+    public static var defaultFormatConfiguration: CodegenFormatConfiguration {
+        CodegenFormatConfiguration()
     }
 
     private var fileManager: FileManager

--- a/Tests/CodegenKitCLITests/ExampleManifesto.swift
+++ b/Tests/CodegenKitCLITests/ExampleManifesto.swift
@@ -1,12 +1,12 @@
 import Foundation
-import SwiftOperators
+import SwiftBasicFormat
 import SwiftSyntax
 import SwiftParser
-import SwiftFormat
+import CodegenKit
 import CodegenKitCLI
 
 struct ExampleManifesto {
-    var formatConfiguration: SwiftFormat.Configuration = RepositoryInitializer.defaultFormatConfiguration
+    var formatConfiguration: CodegenFormatConfiguration = RepositoryInitializer.defaultFormatConfiguration
 
     var hasDefaultLocalization: Bool = false
     var hasPlatforms: Bool = false
@@ -130,14 +130,11 @@ let package = Package(
     }
 
     private func format(source: String) throws -> String {
-        let file = URL(fileURLWithPath: "Package.swift")
         let syntax = Parser.parse(source: source)
-        let formatter = SwiftFormatter(configuration: formatConfiguration)
-        var out = ""
-        try formatter.format(
-            syntax: syntax, source: source, operatorTable: OperatorTable(),
-            assumingFileURL: file, selection: .infinite, to: &out
+        let format = BasicFormat(
+            indentationWidth: .spaces(formatConfiguration.indentationSpaces),
+            viewMode: .fixedUp
         )
-        return out
+        return syntax.formatted(using: format).description
     }
 }

--- a/Tests/CodegenKitTests/BasicTests.swift
+++ b/Tests/CodegenKitTests/BasicTests.swift
@@ -32,11 +32,9 @@ final class BasicTests: XCTestCase {
             """)
         )
         XCTAssertEqual(t.fragments[safe: 1], .placeholder(
-            name: "aaa", content: """
-                func foo0() {}
-                func foo1() {}
-
-            """
+            name: "aaa",
+            indentation: "    ",
+            content: "func foo0() {}\nfunc foo1() {}\n"
         ))
         XCTAssertEqual(t.fragments[safe: 2], .text("""
                 // @end
@@ -58,11 +56,10 @@ final class BasicTests: XCTestCase {
 
         XCTAssertEqual(t.names, ["aaa"])
 
-        t["aaa"] = ("""
-                func foo2() {}
-                func foo3() {}
+        t["aaa"] = """
+            func foo2() {}
+            func foo3() {}
             """
-        )
 
         XCTAssertEqual(t.description, """
             class V {


### PR DESCRIPTION
swift-format への依存があると、swift-syntax のバージョンがロックされてメンテナンスが難しいため、外す。

コード生成側でインデント補正をしなくて良いように導入していたが、
もっとシンプルな仕組みで代替する。

```swift
// @codegen(foo)
```

が書いてあるところのインデントレベルを調べて、
挿入される生成コードに同じインデントを付与するようにする。
